### PR TITLE
Make sure that .py file is used, even if .pyc got executed

### DIFF
--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -34,11 +34,12 @@ easy_install.ScriptWriter.get_args = get_args
 
 
 def main():
+    import re
     import shutil
     import sys
     dests = sys.argv[1:] or ['.']
-    print(__name__)
+    filename = re.sub('\.pyc$', '.py', __file__)
     for dst in dests:
-        shutil.copy(__file__, dst)
+        shutil.copy(filename, dst)
         with open(dst + '/MANIFEST.in', 'a') as manifest:
             manifest.write('\ninclude fastentrypoints.py')

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -49,8 +49,10 @@ def main():
         # Insert the include statement to MANIFEST.in if not present
         with open(manifest_path, 'a+') as manifest:
             manifest.seek(0)
-            if not 'include fastentrypoints.py' in manifest.read():
-                manifest.write('\ninclude fastentrypoints.py')
+            manifest_content = manifest.read()
+            if not 'include fastentrypoints.py' in manifest_content:
+                manifest.write(('\n' if manifest_content else '')
+                               + 'include fastentrypoints.py')
 
         # Insert the import statement to setup.py if not present
         with open(setup_path, 'a+') as setup:

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -45,11 +45,8 @@ def main():
         shutil.copy(filename, dst)
         manifest_path = os.path.join(dst, 'MANIFEST.in')
 
-        # Detect if include statement is already present
-        with open(manifest_path, 'r') as manifest:
-            if 'include fastentrypoints.py' in manifest.read():
-                continue
-
-        # If not present, insert it
-        with open(manifest_path, 'a') as manifest:
-            manifest.write('\ninclude fastentrypoints.py')
+        # Insert the include statement to MANIFEST.in if not present
+        with open(manifest_path, 'a+') as manifest:
+            manifest.seek(0)
+            if not 'include fastentrypoints.py' in manifest.read():
+                manifest.write('\ninclude fastentrypoints.py')

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -44,9 +44,19 @@ def main():
     for dst in dests:
         shutil.copy(filename, dst)
         manifest_path = os.path.join(dst, 'MANIFEST.in')
+        setup_path = os.path.join(dst, 'setup.py')
 
         # Insert the include statement to MANIFEST.in if not present
         with open(manifest_path, 'a+') as manifest:
             manifest.seek(0)
             if not 'include fastentrypoints.py' in manifest.read():
                 manifest.write('\ninclude fastentrypoints.py')
+
+        # Insert the import statement to setup.py if not present
+        with open(setup_path, 'a+') as setup:
+            setup.seek(0)
+            setup_content = setup.read()
+            if not 'import fastentrypoints' in setup_content:
+                setup.seek(0)
+                setup.truncate()
+                setup.write('import fastentrypoints\n' + setup_content)

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -34,12 +34,22 @@ easy_install.ScriptWriter.get_args = get_args
 
 
 def main():
+    import os
     import re
     import shutil
     import sys
     dests = sys.argv[1:] or ['.']
     filename = re.sub('\.pyc$', '.py', __file__)
+
     for dst in dests:
         shutil.copy(filename, dst)
-        with open(dst + '/MANIFEST.in', 'a') as manifest:
+        manifest_path = os.path.join(dst, 'MANIFEST.in')
+
+        # Detect if include statement is already present
+        with open(manifest_path, 'r') as manifest:
+            if 'include fastentrypoints.py' in manifest.read():
+                continue
+
+        # If not present, insert it
+        with open(manifest_path, 'a') as manifest:
             manifest.write('\ninclude fastentrypoints.py')


### PR DESCRIPTION
If python already byte-compiled the source code to .pyc file,
the ```__file__``` points to .pyc, rather than to .py, which breaks the
copying mechanism.

Use regex substitution to make sure we're always copying the original
source file.