### PR TITLE
use 'EASY-INSTALL-ENTRY-SCRIPT:...' header in TEMPLATE

### DIFF
--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -39,6 +39,8 @@ from setuptools.command import easy_install
 import re
 TEMPLATE = '''\
 # -*- coding: utf-8 -*-
+# EASY-INSTALL-ENTRY-SCRIPT: '{3}','{4}','{5}'
+__requires__ = '{3}'
 import re
 import sys
 
@@ -65,7 +67,8 @@ def get_args(cls, dist, header=None):
             if re.search(r'[\\/]', name):
                 raise ValueError("Path separators not allowed in script names")
             script_text = TEMPLATE.format(
-                          ep.module_name, ep.attrs[0], '.'.join(ep.attrs))
+                          ep.module_name, ep.attrs[0], '.'.join(ep.attrs),
+                          spec, group, name)
             args = cls._get_script_args(type_, name, header, script_text)
             for res in args:
                 yield res


### PR DESCRIPTION
Hi,

I made a small addition to the `TEMPLATE` string in order to get the same header metadata in the entry point file as with the regular unpatched `easy_install.ScriptWriter`, i.e. something like:

```python
#!/usr/bin/python
# -*- coding: utf-8 -*-
# EASY-INSTALL-ENTRY-SCRIPT: 'my-module==1.0','console_scripts','my_script'
__requires__ = 'my-module==1.0'
...
```

The two lines after `# -*- coding: utf-8 -*-` are missing when using the current version of `fastentrypoints.py`. This change doesn't affect the speed of calling the entry point.

The reason I changed this is that I'm using the `argcomplete` module that expects the above format.