### PR TITLE
Remove print statement

### DIFF
--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -110,6 +110,3 @@ def main():
                 setup.seek(0)
                 setup.truncate()
                 setup.write('import fastentrypoints\n' + setup_content)
-
-
-print(__name__)


### PR DESCRIPTION
I'm not sure what was the purpose of it, perhaps a leftover when troubleshooting something?

Anyway, that print statement becomes quite obvious since `./setup.py test` is used quite often.