### PR TITLE
Setup: Prevent encoding issue while installing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='0.12',
     py_modules=['fastentrypoints'],
     description='Makes entry_points specified in setup.py load more quickly',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', 'r', encoding='utf-8').read(),
     url='https://github.com/ninjaaron/fast-entry_points',
     author='Aaron Christianson',
     author_email='ninjaaron@gmail.com',


### PR DESCRIPTION
Python opens files using the encoding returned by
locale.getpreferredencoding(), which is 'cp1252' in Windows.
For cross-platform compatibility, it is needed to explicitly
specify 'utf-8' when reading files.

File is also opened in read-only since it is not necessary
to have write access to README files during install.