### PR TITLE
Add .travis.yml and virtualenv editable testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - 2.7
+  - 3.7
+before_install: pip install virtualenv pathlib2
+install: pip install .
+script: python test/runtest.py

--- a/README.rst
+++ b/README.rst
@@ -80,5 +80,3 @@ Test
 There is one test. To run it, do ``test/runtest.py``. It installs a
 dummy package with fastentrypoints and ensures the generated script is
 what is expected.
-
-It requires Python 3.5 or higher because it uses ``subprocess.run``.

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
-import subprocess as sp
+import difflib
 import os
-import pathlib
+#import pathlib
 import shutil
+import subprocess
+import sys
+try:
+    import pathlib2 as pathlib
+except:
+    import pathlib
 
 TEST_DIR = pathlib.Path(__file__).absolute().parent
 PROJECT_DIR = TEST_DIR.parent
 EXPECTED_OUTPUT = r"""# -*- coding: utf-8 -*-
-# EASY-INSTALL-ENTRY-SCRIPT: 'dummypkg==0.0.0','console_scripts','hello'
-__requires__ = 'dummypkg==0.0.0'
+# EASY-INSTALL-ENTRY-SCRIPT: 'dummypkg{version}','console_scripts','hello'
+__requires__ = 'dummypkg{version}'
 import re
 import sys
 
@@ -16,8 +22,23 @@ from dummy import main
 
 if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
-    sys.exit(main())
-"""
+    sys.exit(main())"""
+
+# Python 2 needs virtualenv, and Travis already executes in a virtualenv
+use_virtualenv = True
+use_editable = True
+
+if use_editable:
+    EXPECTED_OUTPUT = EXPECTED_OUTPUT.format(version="")
+else:
+    EXPECTED_OUTPUT = EXPECTED_OUTPUT.format(version="==0.0.0")
+
+
+def run(*args, **kwargs):
+    if sys.version_info >= (3, 5):
+        subprocess.run(*args, check=True, **kwargs)
+    else:
+        subprocess.call(*args, **kwargs)
 
 
 def main():
@@ -25,14 +46,22 @@ def main():
     shutil.copy2(str(PROJECT_DIR/"fastentrypoints.py"), str(fep_copy))
 
     testenv = pathlib.Path("testenv")
-    sp.run(["python3", "-m", "venv", str(testenv)], check=True)
     pip = testenv / "bin" / "pip"
-    sp.run([str(pip), "install", TEST_DIR], check=True)
+    if use_virtualenv:
+        run([sys.executable, "-m", "virtualenv", str(testenv)])
+    else:
+        run([sys.executable, "-m", "venv", str(testenv)])
+
+    if use_editable:
+        run([str(pip), "install", "-e", str(TEST_DIR)])
+    else:
+        run([str(pip), "install", str(TEST_DIR)])
 
     try:
         with open(str(testenv / "bin" / "hello")) as output:
             output.readline()  # eat shabang line, which is non-deterministic.
-            assert output.read() == EXPECTED_OUTPUT
+            result = output.read().strip()
+            assert result == EXPECTED_OUTPUT
     finally:
         shutil.rmtree(str(testenv))
         os.remove(str(fep_copy))


### PR DESCRIPTION
Travis language python already sets up a virtualenv, making
`venv` use problematic.  Also pip defaults to building wheels
which doesnt test the primary objective of this tool.

Using `pip install -e` is closer to the raw `setup.py install`.
The old Python 3 only venv test code is still in place, but not
accessible to the CLI.