### PR TITLE
Remove redundant import

### DIFF
--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -84,7 +84,6 @@ easy_install.ScriptWriter.get_args = get_args
 
 def main():
     import os
-    import re
     import shutil
     import sys
     dests = sys.argv[1:] or ['.']


### PR DESCRIPTION
You don't need to import the `re` module again inside the `main` function